### PR TITLE
Add known state to peer to allow quick connection on restart

### DIFF
--- a/source/comms/src/controller.rs
+++ b/source/comms/src/controller.rs
@@ -353,7 +353,7 @@ async fn update_known<T: FrameSerial>(
             continue;
         };
 
-        if instant + KNOWN_TIMEOUT >= Instant::now() {
+        if instant + KNOWN_TIMEOUT <= Instant::now() {
             p.reset_to_free();
             continue;
         }

--- a/source/comms/src/controller.rs
+++ b/source/comms/src/controller.rs
@@ -5,7 +5,7 @@
 use core::{fmt::Debug, ops::DerefMut};
 
 use embassy_sync::{blocking_mutex::raw::RawMutex, mutex::Mutex};
-use embassy_time::{with_timeout, Duration, TimeoutError};
+use embassy_time::{with_timeout, Duration, TimeoutError, Instant};
 use rand_core::RngCore;
 
 use crate::{
@@ -16,6 +16,9 @@ use crate::{
 
 /// Time that a Controller will wait for a Target to respond
 pub const REPLY_TIMEOUT: Duration = Duration::from_millis(1);
+
+/// Time that a peer can be in the Known state before getting reset to Free
+pub const KNOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Controller interface and data storage
 ///
@@ -122,6 +125,7 @@ impl<R: RawMutex + 'static> Controller<R> {
         let mut inner = self.peers.lock().await;
         serve_peers(inner.deref_mut(), serial).await?;
         complete_pendings(inner.deref_mut(), serial).await?;
+        update_known(inner.deref_mut(), serial).await?;
         offer_addr(inner.deref_mut(), serial, rand).await?;
         Ok(())
     }
@@ -167,6 +171,20 @@ impl<R: RawMutex + 'static> Controller<R> {
             .iter()
             .filter_map(|p| p.is_active().then_some(p.mac()))
             .collect()
+    }
+
+    /// Adds a list of macs to the peers as known peers
+    pub async fn add_known_macs(&self, mut macs: heapless::Vec<u64, { MAX_TARGETS }>) {
+        self.peers
+            .lock()
+            .await
+            .iter_mut()
+            .for_each(|p| {
+                if !macs.is_empty() && p.is_idle() {
+                    let mac = macs.pop().expect("No mac to pop");
+                    p.promote_to_known_with_mac(mac);
+                }
+            })
     }
 }
 
@@ -324,6 +342,59 @@ async fn complete_pendings<T: FrameSerial>(
     Ok(())
 }
 
+/// A helper function for moving targets from the Known stage to either the Active stage or to the Free stage
+async fn update_known<T: FrameSerial>(
+    inner: &mut [Peer; MAX_TARGETS],
+    serial: &mut T,
+) -> Result<(), Error<T::SerError>> {
+    for (i, p) in inner.iter_mut().enumerate() {
+        // Only worry about pending nodes
+        let Some((mac, instant)) = p.is_known() else {
+            continue;
+        };
+
+        if instant + KNOWN_TIMEOUT >= Instant::now() {
+            p.reset_to_free();
+            continue;
+        }
+
+        // Send a message with the expected MAC address for confirmation
+        let mut out_buf = [0u8; 9];
+        out_buf[0] = CmdAddr::DiscoverySuccess(i as u8).into();
+        out_buf[1..9].copy_from_slice(&mac.to_le_bytes());
+
+        // We should only get back an empty ACK and nothing else
+        let mut in_buf = [0u8; 2];
+        serial.send_frame(&out_buf).await?;
+        let rxto = with_timeout(REPLY_TIMEOUT, serial.recv(&mut in_buf));
+
+        match rxto.await {
+            Ok(Ok(tf)) => {
+                let frame = tf.frame;
+                let good_len = frame.len() == 1;
+                let good_hdr = good_len && frame[0] == CmdAddr::ReplyFromAddr(i as u8).into();
+                if good_hdr {
+                    nut_info!("Promoting to active {=usize} {=u64}", i, mac);
+                    p.promote_to_active();
+                } else {
+                    p.increment_error();
+                }
+            }
+            Ok(Err(_e)) => {
+                // We got some kind of receive error, just mark this as
+                // an error and move on
+                p.increment_error();
+                continue;
+            }
+            Err(TimeoutError) => {
+                // No answer? No address.
+                p.increment_error();
+            }
+        }
+    }
+    Ok(())
+}
+
 /// A helper function for moving new nodes into the Pending stage
 async fn offer_addr<T: FrameSerial, R: RngCore>(
     inner: &mut [Peer; MAX_TARGETS],
@@ -357,6 +428,8 @@ async fn offer_addr<T: FrameSerial, R: RngCore>(
                     .zip(rand_iter.zip(resp_iter))
                     .for_each(|(d, (a, b))| *d = *a ^ *b);
 
+
+                // If the mac is known in the list already it will time out soonish anyway
                 p.promote_to_pending(u64::from_le_bytes(mac));
             }
         }

--- a/source/comms/src/peer.rs
+++ b/source/comms/src/peer.rs
@@ -47,8 +47,9 @@ impl<const IN: usize, const OUT: usize> Peer<IN, OUT> {
     }
 
     pub(crate) fn promote_to_active(&mut self) {
-        if self.state != State::Pending {
-            panic!();
+        match self.state {
+            State::Pending | State::Known(_) => (),
+            _ => panic!(),
         }
         // mac is already set
         self.to_peer.clear();

--- a/source/comms/src/peer.rs
+++ b/source/comms/src/peer.rs
@@ -1,6 +1,7 @@
 //! Peer
 
 use crate::frame_pool::{FrameBox, RawFrameSlice};
+use embassy_time::Instant;
 use heapless::Deque;
 
 /// The default number of "in-flight" packets FROM Controller TO Target
@@ -13,6 +14,7 @@ enum State {
     Free,
     Pending,
     Active,
+    Known(Instant),
 }
 
 pub(crate) struct Peer<const IN: usize = INCOMING_SIZE, const OUT: usize = OUTGOING_SIZE> {
@@ -36,7 +38,7 @@ impl<const IN: usize, const OUT: usize> Peer<IN, OUT> {
         }
     }
 
-    fn reset_to_free(&mut self) {
+    pub(crate) fn reset_to_free(&mut self) {
         self.to_peer.clear();
         self.from_peer.clear();
         self.mac = 0;
@@ -52,6 +54,28 @@ impl<const IN: usize, const OUT: usize> Peer<IN, OUT> {
         self.to_peer.clear();
         self.from_peer.clear();
         self.state = State::Active;
+        self.counter = 0;
+    }
+
+    pub(crate) fn reset_to_known(&mut self) {
+        if self.state != State::Active {
+            panic!();
+        }
+        // mac is already set
+        self.to_peer.clear();
+        self.from_peer.clear();
+        self.state = State::Known(Instant::now());
+        self.counter = 0;
+    }
+
+    pub(crate) fn promote_to_known_with_mac(&mut self, mac: u64) {
+        if self.state != State::Free {
+            panic!();
+        }
+        self.mac = mac;
+        self.to_peer.clear();
+        self.from_peer.clear();
+        self.state = State::Known(Instant::now());
         self.counter = 0;
     }
 
@@ -75,6 +99,9 @@ impl<const IN: usize, const OUT: usize> Peer<IN, OUT> {
             State::Free => {
                 // uh?
             }
+            State::Known(_) => {
+                // We currently ignore errors while in the known state. This may or may not be a mistake
+            }
             State::Pending => {
                 // one strike, you're out!
                 self.reset_to_free();
@@ -90,8 +117,8 @@ impl<const IN: usize, const OUT: usize> Peer<IN, OUT> {
                 // moving from Active -> Free with a timestamp.
                 self.counter += 1;
                 if self.counter > 3 {
-                    nut_warn!("Resetting active device");
-                    self.reset_to_free();
+                    nut_warn!("Resetting active device to known");
+                    self.reset_to_known();
                 }
             }
         }
@@ -109,6 +136,15 @@ impl<const IN: usize, const OUT: usize> Peer<IN, OUT> {
     #[inline]
     pub(crate) fn is_active(&self) -> bool {
         self.state == State::Active
+    }
+
+    #[inline]
+    pub(crate) fn is_known(&self) -> Option<(u64, Instant)> {
+        if let State::Known(instant) = self.state {
+            Some((self.mac, instant))
+        } else {
+            None
+        }
     }
 
     #[inline]

--- a/source/comms/src/target.rs
+++ b/source/comms/src/target.rs
@@ -56,6 +56,11 @@ impl<S> From<crate::Error<S>> for TargetError<S> {
     }
 }
 
+enum OfferResponse {
+    OfferFrame((u8, [u8; 8])),
+    SuccessFrame(u8)
+}
+
 /// Interface for the Target
 ///
 /// Note that UNLIKE the [`Controller`][crate::Controller], which uses a Mutex to share between the
@@ -177,11 +182,19 @@ where
     async fn get_addr(&mut self) -> u8 {
         loop {
             nut_info!("get_addr...");
-            let goforit = self.rand.next_u32();
-
+            
+            let mut offer_addr = 0;
+            let mut offer_challenge: [u8; 8] = [0; 8];
             // Wait for an offer frame
-            let (offer_addr, offer_challenge) = self.get_offer().await;
-
+            let offer_response = self.get_offer().await;
+            if let OfferResponse::SuccessFrame(addr) = offer_response {
+                return addr;
+            } else if let OfferResponse::OfferFrame((offer_ad, offer_chall)) = offer_response {
+                offer_addr = offer_ad;
+                offer_challenge = offer_chall;
+            }
+            
+            let goforit = self.rand.next_u32();
             // do we go for it? (1/8 chance)
             if goforit & 0b0000_0111 != 0 {
                 nut_info!("skipping!");
@@ -268,7 +281,7 @@ where
         Ok(())
     }
 
-    async fn get_offer(&mut self) -> (u8, [u8; 8]) {
+    async fn get_offer(&mut self) -> OfferResponse {
         // offer should be 1 + 8 + 1 for line break
         let mut scratch = [0u8; 16];
         loop {
@@ -286,18 +299,19 @@ where
             else {
                 continue;
             };
-            // Is this an offer?
-            let CmdAddr::DiscoveryOffer(addr) = ca else {
-                continue;
-            };
             // Is this long enough?
             if tframe.frame.len() < 9 {
                 continue;
             }
-            let mut challenge = [0u8; 8];
-            challenge.copy_from_slice(&tframe.frame[1..9]);
+            // Is this an offer?
+            if let CmdAddr::DiscoveryOffer(addr) = ca {
+                let mut challenge = [0u8; 8];
+                challenge.copy_from_slice(&tframe.frame[1..9]);
 
-            return (addr, challenge);
+                return OfferResponse::OfferFrame((addr, challenge))
+            } else if let CmdAddr::DiscoverySuccess(addr) = ca {
+                return OfferResponse::SuccessFrame(addr)
+            }
         }
     }
 }


### PR DESCRIPTION
~The changes in this PR are currently untested as I don't yet have a full setup with multiple rp2040, but I'm working on testing it this weekend.~
Edit: I've now tested this PR, after a small fix everything works as expected

The PR adds a new `known` state to the peers as a state for peers with known peers but without connection.

In the `known` state the controller regularly will send out `DiscoverySuccess` messages until either the peer answers (and will get promoted to the `active` state) or until the `KNOWN_TIMEOUT` (currently five seconds) has passed at which point the peer will get reset to a free (idle) peer.

This allows users to save known macs before a restart of the controller and preload the macs into the controller for faster connections.
It also allows existing peers a grace period to restart where they will still get the same address afterwards.

I've opened this as draft for discussion