### PR TITLE
Provide events/signals on state change for peers and target

### DIFF
--- a/source/comms/src/lib.rs
+++ b/source/comms/src/lib.rs
@@ -162,6 +162,7 @@ pub mod target;
 #[cfg(feature = "postcard-rpc-helpers")]
 pub mod wirehelp;
 use embassy_time::Instant;
+pub use crate::peer::Event as PeerEvent;
 
 /// The maximum number of Targets supported by a Controller.
 pub const MAX_TARGETS: usize = 31;


### PR DESCRIPTION
What the title says, this can be easily used to print out a log message on a connection change or to update a routing table in the controller.

I'm not that happy with the implementation for the controller, it's creating a new heapless Vec with a size of `MAX_TARGETS` every step, it might be better to return a reference to a Vec we update each step or something similar. I'm open to suggestions.

For the target there is a method commented out as it needs `embassy_sync::Signal.try_take` which apparently doesn't exist yet in the version erdnuss-pub currently depends on