### PR TITLE
Bump all dependency versions

### DIFF
--- a/source/comms/Cargo.lock
+++ b/source/comms/Cargo.lock
@@ -100,6 +100,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "embassy-sync"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,19 +123,37 @@ dependencies = [
 
 [[package]]
 name = "embassy-time"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a2fc78331899dc7ba8fbcae2fcac3f5cd5301c0717689c546af2ce4162d4e4"
+checksum = "a9c844070d9f80dc66ee739299183312baee2e1cdeb6e90b4ea2af44f4676da5"
 dependencies = [
  "cfg-if",
  "critical-section",
  "defmt",
+ "document-features",
+ "embassy-time-driver",
+ "embassy-time-queue-driver",
  "embedded-hal 0.2.7",
- "embedded-hal 1.0.0-rc.2",
+ "embedded-hal 1.0.0",
  "embedded-hal-async",
  "futures-util",
  "heapless 0.8.0",
 ]
+
+[[package]]
+name = "embassy-time-driver"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e0c214077aaa9206958b16411c157961fb7990d4ea628120a78d1a5a28aed24"
+dependencies = [
+ "document-features",
+]
+
+[[package]]
+name = "embassy-time-queue-driver"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1177859559ebf42cd24ae7ba8fe6ee707489b01d0bf471f8827b7b12dcb0bc0"
 
 [[package]]
 name = "embedded-hal"
@@ -140,17 +167,17 @@ dependencies = [
 
 [[package]]
 name = "embedded-hal"
-version = "1.0.0-rc.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e57ec6ad0bc8eb967cf9c9f144177f5e8f2f6f02dad0b8b683f9f05f6b22def"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
 name = "embedded-hal-async"
-version = "1.0.0-rc.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5ad4a01f9cb38117ef85f5cd32176d63875e7eab99c5b60e8492bfdc16dd63"
+checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
 dependencies = [
- "embedded-hal 1.0.0-rc.2",
+ "embedded-hal 1.0.0",
 ]
 
 [[package]]
@@ -178,7 +205,7 @@ dependencies = [
  "embassy-time",
  "futures",
  "grounded",
- "heapless 0.7.16",
+ "heapless 0.8.0",
  "postcard",
  "postcard-rpc",
  "rand_core",
@@ -308,6 +335,12 @@ dependencies = [
  "hash32 0.3.1",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"

--- a/source/comms/Cargo.toml
+++ b/source/comms/Cargo.toml
@@ -12,7 +12,7 @@ documentation   = "https://docs.rs/erdnuss-comms/"
 [dependencies]
 embassy-sync        = "0.5.0"
 grounded            = "0.2"
-heapless            = "0.7.0"
+heapless            = "0.8.0"
 rand_core           = "0.6.4"
 critical-section    = "1.1.2"
 
@@ -21,11 +21,11 @@ version             = "0.3"
 optional            = true
 
 [dependencies.embassy-time]
-version             = "0.2"
+version             = "0.3"
 features            = ["defmt", "defmt-timestamp-uptime"]
 
 [dependencies.futures]
-version             = "0.3.29"
+version             = "0.3.30"
 default-features    = false
 features            = ["async-await"]
 

--- a/source/rp2040/Cargo.lock
+++ b/source/rp2040/Cargo.lock
@@ -262,6 +262,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef5282ad69563b5fc40319526ba27e0e7363d552a896f0297d54f767717f9b95"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,13 +279,13 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 [[package]]
 name = "embassy-embedded-hal"
 version = "0.1.0"
-source = "git+https://github.com/jamesmunns/embassy?rev=06b74a30342c527b70acbb8bacf919a5efc67c3d#06b74a30342c527b70acbb8bacf919a5efc67c3d"
+source = "git+https://github.com/embassy-rs/embassy?rev=b7bc31e51a6c6be658acc9f09bed41b94ea57623#b7bc31e51a6c6be658acc9f09bed41b94ea57623"
 dependencies = [
- "embassy-futures",
- "embassy-sync 0.5.0 (git+https://github.com/jamesmunns/embassy?rev=06b74a30342c527b70acbb8bacf919a5efc67c3d)",
+ "embassy-futures 0.1.1 (git+https://github.com/embassy-rs/embassy?rev=b7bc31e51a6c6be658acc9f09bed41b94ea57623)",
+ "embassy-sync 0.5.0 (git+https://github.com/embassy-rs/embassy?rev=b7bc31e51a6c6be658acc9f09bed41b94ea57623)",
  "embassy-time",
  "embedded-hal 0.2.7",
- "embedded-hal 1.0.0-rc.3",
+ "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-storage",
  "embedded-storage-async",
@@ -286,12 +295,18 @@ dependencies = [
 [[package]]
 name = "embassy-futures"
 version = "0.1.1"
-source = "git+https://github.com/jamesmunns/embassy?rev=06b74a30342c527b70acbb8bacf919a5efc67c3d#06b74a30342c527b70acbb8bacf919a5efc67c3d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f878075b9794c1e4ac788c95b728f26aa6366d32eeb10c7051389f898f7d067"
+
+[[package]]
+name = "embassy-futures"
+version = "0.1.1"
+source = "git+https://github.com/embassy-rs/embassy?rev=b7bc31e51a6c6be658acc9f09bed41b94ea57623#b7bc31e51a6c6be658acc9f09bed41b94ea57623"
 
 [[package]]
 name = "embassy-hal-internal"
 version = "0.1.0"
-source = "git+https://github.com/jamesmunns/embassy?rev=06b74a30342c527b70acbb8bacf919a5efc67c3d#06b74a30342c527b70acbb8bacf919a5efc67c3d"
+source = "git+https://github.com/embassy-rs/embassy?rev=b7bc31e51a6c6be658acc9f09bed41b94ea57623#b7bc31e51a6c6be658acc9f09bed41b94ea57623"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -302,7 +317,7 @@ dependencies = [
 [[package]]
 name = "embassy-rp"
 version = "0.1.0"
-source = "git+https://github.com/jamesmunns/embassy?rev=06b74a30342c527b70acbb8bacf919a5efc67c3d#06b74a30342c527b70acbb8bacf919a5efc67c3d"
+source = "git+https://github.com/embassy-rs/embassy?rev=b7bc31e51a6c6be658acc9f09bed41b94ea57623#b7bc31e51a6c6be658acc9f09bed41b94ea57623"
 dependencies = [
  "atomic-polyfill",
  "cfg-if",
@@ -310,14 +325,16 @@ dependencies = [
  "cortex-m-rt",
  "critical-section",
  "defmt",
+ "document-features",
  "embassy-embedded-hal",
- "embassy-futures",
+ "embassy-futures 0.1.1 (git+https://github.com/embassy-rs/embassy?rev=b7bc31e51a6c6be658acc9f09bed41b94ea57623)",
  "embassy-hal-internal",
- "embassy-sync 0.5.0 (git+https://github.com/jamesmunns/embassy?rev=06b74a30342c527b70acbb8bacf919a5efc67c3d)",
+ "embassy-sync 0.5.0 (git+https://github.com/embassy-rs/embassy?rev=b7bc31e51a6c6be658acc9f09bed41b94ea57623)",
  "embassy-time",
+ "embassy-time-driver",
  "embassy-usb-driver",
  "embedded-hal 0.2.7",
- "embedded-hal 1.0.0-rc.3",
+ "embedded-hal 1.0.0",
  "embedded-hal-async",
  "embedded-hal-nb",
  "embedded-io",
@@ -350,7 +367,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.5.0"
-source = "git+https://github.com/jamesmunns/embassy?rev=06b74a30342c527b70acbb8bacf919a5efc67c3d#06b74a30342c527b70acbb8bacf919a5efc67c3d"
+source = "git+https://github.com/embassy-rs/embassy?rev=b7bc31e51a6c6be658acc9f09bed41b94ea57623#b7bc31e51a6c6be658acc9f09bed41b94ea57623"
 dependencies = [
  "cfg-if",
  "critical-section",
@@ -361,23 +378,39 @@ dependencies = [
 
 [[package]]
 name = "embassy-time"
-version = "0.2.0"
-source = "git+https://github.com/jamesmunns/embassy?rev=06b74a30342c527b70acbb8bacf919a5efc67c3d#06b74a30342c527b70acbb8bacf919a5efc67c3d"
+version = "0.3.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=b7bc31e51a6c6be658acc9f09bed41b94ea57623#b7bc31e51a6c6be658acc9f09bed41b94ea57623"
 dependencies = [
  "cfg-if",
  "critical-section",
  "defmt",
+ "document-features",
+ "embassy-time-driver",
+ "embassy-time-queue-driver",
  "embedded-hal 0.2.7",
- "embedded-hal 1.0.0-rc.3",
+ "embedded-hal 1.0.0",
  "embedded-hal-async",
  "futures-util",
  "heapless 0.8.0",
 ]
 
 [[package]]
+name = "embassy-time-driver"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=b7bc31e51a6c6be658acc9f09bed41b94ea57623#b7bc31e51a6c6be658acc9f09bed41b94ea57623"
+dependencies = [
+ "document-features",
+]
+
+[[package]]
+name = "embassy-time-queue-driver"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=b7bc31e51a6c6be658acc9f09bed41b94ea57623#b7bc31e51a6c6be658acc9f09bed41b94ea57623"
+
+[[package]]
 name = "embassy-usb-driver"
 version = "0.1.0"
-source = "git+https://github.com/jamesmunns/embassy?rev=06b74a30342c527b70acbb8bacf919a5efc67c3d#06b74a30342c527b70acbb8bacf919a5efc67c3d"
+source = "git+https://github.com/embassy-rs/embassy?rev=b7bc31e51a6c6be658acc9f09bed41b94ea57623#b7bc31e51a6c6be658acc9f09bed41b94ea57623"
 dependencies = [
  "defmt",
 ]
@@ -394,26 +427,26 @@ dependencies = [
 
 [[package]]
 name = "embedded-hal"
-version = "1.0.0-rc.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc402f79e1fd22731ca945b4f97b5ff37e7b3f379312595c42bb2e8811c29920"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
 name = "embedded-hal-async"
-version = "1.0.0-rc.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fba2ef2ffb35d614acc6fb323ddf7facc45c069f24544d49ea54e5043626d"
+checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
 dependencies = [
- "embedded-hal 1.0.0-rc.3",
+ "embedded-hal 1.0.0",
 ]
 
 [[package]]
 name = "embedded-hal-nb"
-version = "1.0.0-rc.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cde58312a0675b6c0389eb0dceb2bf8c735a697b0b5baa1f23bbaf030636deb"
+checksum = "fba4268c14288c828995299e59b12babdbe170f6c6d73731af1b4648142e8605"
 dependencies = [
- "embedded-hal 1.0.0-rc.3",
+ "embedded-hal 1.0.0",
  "nb 1.1.0",
 ]
 
@@ -464,14 +497,14 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erdnuss-comms"
-version = "0.99.9"
+version = "0.999.99"
 dependencies = [
  "critical-section",
  "embassy-sync 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "embassy-time",
  "futures",
  "grounded",
- "heapless 0.7.17",
+ "heapless 0.8.0",
  "postcard",
  "postcard-rpc",
  "rand_core",
@@ -482,7 +515,7 @@ dependencies = [
 name = "erdnuss-rp2040"
 version = "0.9.9"
 dependencies = [
- "embassy-futures",
+ "embassy-futures 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "embassy-rp",
  "embassy-time",
  "erdnuss-comms",
@@ -519,9 +552,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "futures"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0290714b38af9b4a7b094b8a37086d1b4e61f2df9122c3cad2577669145335"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -533,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4dd66668b557604244583e3e1e1eada8c5c2e96a6d0d6653ede395b78bbacb"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -543,21 +576,21 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b153fd91e4b0147f4aced87be237c98248656bb01050b96bf3ee89220a8ddb"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -566,21 +599,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd193069b0ddadc69c46389b740bbccdd97203899b48d09c5f7969591d6bae2"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19526d624e703a3179b3d322efec918b6246ea0fa51d41124525f00f1cc8104"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
  "futures-macro",
@@ -757,6 +790,12 @@ name = "linux-raw-sys"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"

--- a/source/rp2040/Cargo.toml
+++ b/source/rp2040/Cargo.toml
@@ -10,10 +10,10 @@ license         = "MPL-2.0"
 documentation   = "https://docs.rs/erdnuss-rp2040/"
 
 [dependencies]
-embassy-futures     = "0.1.0"
+embassy-futures     = "0.1.1"
 
 [dependencies.erdnuss-comms]
-version             = "0.99"
+version             = "0.999"
 path                = "../comms"
 
 [dependencies.embassy-rp]
@@ -21,7 +21,7 @@ version             = "0.1.0"
 features            = ["defmt", "unstable-pac", "time-driver", "critical-section-impl"]
 
 [dependencies.embassy-time]
-version             = "0.2"
+version             = "0.3"
 features            = ["defmt", "defmt-timestamp-uptime"]
 
 [dependencies.rand_chacha]
@@ -30,14 +30,10 @@ default-features    = false
 
 
 [patch.crates-io.embassy-rp]
-git = "https://github.com/jamesmunns/embassy"
-rev = "06b74a30342c527b70acbb8bacf919a5efc67c3d"
+git = "https://github.com/embassy-rs/embassy"
+rev = "b7bc31e51a6c6be658acc9f09bed41b94ea57623"
 
 [patch.crates-io.embassy-time]
-git = "https://github.com/jamesmunns/embassy"
-rev = "06b74a30342c527b70acbb8bacf919a5efc67c3d"
-
-[patch.crates-io.embassy-futures]
-git = "https://github.com/jamesmunns/embassy"
-rev = "06b74a30342c527b70acbb8bacf919a5efc67c3d"
+git = "https://github.com/embassy-rs/embassy"
+rev = "b7bc31e51a6c6be658acc9f09bed41b94ea57623"
 

--- a/source/rp2040/src/lib.rs
+++ b/source/rp2040/src/lib.rs
@@ -3,7 +3,7 @@
 use erdnuss_comms::TimedFrame;
 use embassy_rp::{
     flash::{Blocking, Flash},
-    gpio::{AnyPin, Output},
+    gpio::Output,
     peripherals::FLASH,
     uart::{Async, Instance, Uart},
 };
@@ -37,11 +37,11 @@ pub fn get_rand(unique_id: u64) -> ChaCha8Rng {
 
 pub struct Rs485Uart<T: Instance + 'static> {
     uart: Uart<'static, T, Async>,
-    pin: Output<'static, AnyPin>,
+    pin: Output<'static>,
 }
 
 impl<T: Instance + 'static> Rs485Uart<T> {
-    pub fn new(uart: Uart<'static, T, Async>, mut pin: Output<'static, AnyPin>) -> Self {
+    pub fn new(uart: Uart<'static, T, Async>, mut pin: Output<'static>) -> Self {
         pin.set_low();
         Self { uart, pin }
     }


### PR DESCRIPTION
Since we want the embassy-rp `read_to_break` bugfix we depend on the latest revision there. This also means we get the new `Output` generic changes